### PR TITLE
Fixed compilation for MSVC C++17

### DIFF
--- a/cevelop-workspace/scope17/src/Test.cpp
+++ b/cevelop-workspace/scope17/src/Test.cpp
@@ -29,7 +29,17 @@ SOFTWARE.
 #include <fstream>
 #include <cstdio>
 #include <fcntl.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#define _T(str) str
+#else
+#include <io.h>
+#define _T(str) L##str
+#define open _open
+#define close _close
+#define unlink _unlink
+#define write _write
+#endif
 
 #include <string>
 
@@ -63,7 +73,7 @@ void DemoFstream(){
 
 using std::filesystem::path;
 void copy_file_transact(path const & from, path const & to) {
-   path t = to.native() + ".deleteme";
+   path t = to.native() + _T(".deleteme");
    auto guard= scope_fail{ [t]{remove(t);} };
    copy_file(from, t);
    rename(t, to);

--- a/cevelop-workspace/scope17/src/Test.cpp
+++ b/cevelop-workspace/scope17/src/Test.cpp
@@ -31,10 +31,8 @@ SOFTWARE.
 #include <fcntl.h>
 #ifndef _MSC_VER
 #include <unistd.h>
-#define _T(str) str
 #else
 #include <io.h>
-#define _T(str) L##str
 #define open _open
 #define close _close
 #define unlink _unlink
@@ -73,7 +71,8 @@ void DemoFstream(){
 
 using std::filesystem::path;
 void copy_file_transact(path const & from, path const & to) {
-   path t = to.native() + _T(".deleteme");
+   path t{to};
+   t += path{".deleteme"};
    auto guard= scope_fail{ [t]{remove(t);} };
    copy_file(from, t);
    rename(t, to);


### PR DESCRIPTION
compiles in VisualStudio 2019
there might be a lots of warnings about not using secure functions
_CRT_SECURE_NO_WARNINGS defined will suppress that warning

#4 